### PR TITLE
Fix example: id_token_signed_response_alg is not an array

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -474,7 +474,7 @@
                     "response_mode" : "form_post",
                     "registration" : {
                         "jwks_uri" : "https://uniresolver.io/1.0/identifiers/did:example:0xab;transform-keys=jwks",
-                        "id_token_signed_response_alg" : [ "ES256K", "EdDSA", "RS256" ]
+                        "id_token_signed_response_alg" : "ES256K"
                     }
                 }
             </pre>


### PR DESCRIPTION
The example uses an array for `id_token_signed_response_alg` but this is a single-valued field per https://openid.net/specs/openid-connect-registration-1_0.html