### PR TITLE
Allow the SIOP Request to specify requested claims (to be provided as as VCs)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -490,6 +490,19 @@
                     without any in-band redirection back to the RP. This behavior is useful in cross-device workflows where
                     it's appropriate for the mobile portion of the flow to terminate in the wallet.
                 </p>
+                <li>
+                    OPTIONAL. <code>claims</code> follows the
+                    <a href="https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter">OIDC Core schema</a>,
+                    addsing a top-level <code>vc</code> property as a sibling to (and following the schema of) <code>id_token</code>
+                    and <code>userinfo</code>. Requesting claims within the <code>vc</code> set indicates that the requesting party
+                    would like to receive (if <code>essential</code> is <code>false</code>), or requires (if <code>true</code>)
+                    a specific set of verifiable credential types within the <code>vc</code> claim of the SIOP Response. Specific
+                    claims are requested using a full URI for the requested VC type.
+                </li>
+                <p class="note">
+                    When providing claims in this manner, the SIOP Response acts as a W3C Verifiable Presentation; requested claims
+                    are provided in the Response by populating the array of Verifiable Credentials within the Presentation.
+                </p>
             </ul>
 
             <p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -497,7 +497,7 @@
                     and <code>userinfo</code>. Requesting claims within the <code>vc</code> set indicates that the requesting party
                     would like to receive (if <code>essential</code> is <code>false</code>), or requires (if <code>true</code>)
                     a specific set of verifiable credential types within the <code>.vp.verifiableCredential</code> array of the
-                    SIOP Response. Specific VC types are are identified using the VC type's full URI. 
+                    SIOP Response. Specific [VC types](https://www.w3.org/TR/vc-data-model/#types) are identified using the VC type's full URI. 
                 </li>
                 <p class="note">
                     When providing claims in this manner, the SIOP Response acts as a W3C Verifiable Presentation; requested claims

--- a/docs/index.html
+++ b/docs/index.html
@@ -496,8 +496,8 @@
                     adding a top-level <code>vc</code> property as a sibling to (and following the schema of) <code>id_token</code>
                     and <code>userinfo</code>. Requesting claims within the <code>vc</code> set indicates that the requesting party
                     would like to receive (if <code>essential</code> is <code>false</code>), or requires (if <code>true</code>)
-                    a specific set of verifiable credential types within the <code>vc</code> claim of the SIOP Response. Specific
-                    VC types are are identified using the type's full URI.
+                    a specific set of verifiable credential types within the <code>.vp.verifiableCredential</code> array of the
+                    SIOP Response. Specific VC types are are identified using the VC type's full URI. 
                 </li>
                 <p class="note">
                     When providing claims in this manner, the SIOP Response acts as a W3C Verifiable Presentation; requested claims

--- a/docs/index.html
+++ b/docs/index.html
@@ -493,11 +493,11 @@
                 <li>
                     OPTIONAL. <code>claims</code> follows the
                     <a href="https://openid.net/specs/openid-connect-core-1_0.html#ClaimsParameter">OIDC Core schema</a>,
-                    addsing a top-level <code>vc</code> property as a sibling to (and following the schema of) <code>id_token</code>
+                    adding a top-level <code>vc</code> property as a sibling to (and following the schema of) <code>id_token</code>
                     and <code>userinfo</code>. Requesting claims within the <code>vc</code> set indicates that the requesting party
                     would like to receive (if <code>essential</code> is <code>false</code>), or requires (if <code>true</code>)
                     a specific set of verifiable credential types within the <code>vc</code> claim of the SIOP Response. Specific
-                    claims are requested using a full URI for the requested VC type.
+                    VC types are are identified using the type's full URI.
                 </li>
                 <p class="note">
                     When providing claims in this manner, the SIOP Response acts as a W3C Verifiable Presentation; requested claims


### PR DESCRIPTION
The OIDC protocol provides a way to negotiate specific claims within an id_token or at the userinfo endpoint. When used with DID SIOP, it's especially useful to request claims in the form of VCs, embedded in the SIOP response (i.e., treat the SIOP response as a W3C Verifiable Presentation, and include specific requested claims in the VC array).