### PR TITLE
Match "RECOMMENDS" to "SHOULD"

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -639,7 +639,7 @@
 
         <h3 id="encryption">Encryption</h3>
         <p>
-            JWE encryption MUST use Diffie-Hellman key agreement, i.e., algorithm `ECDH-ES` using the `X25519` curve
+            JWE encryption SHOULD use Diffie-Hellman key agreement, i.e., algorithm `ECDH-ES` using the `X25519` curve
             which uses direct key agreement with an ephemeral key. This means that a symmetric key is derived using
             Diffie-Hellman from the <a href="#rp">RP's</a> public key and a randomly generated ephemeral private key.
             The corresponding ephemeral public key is included in the header of the JWE in the `epk` and the derived


### PR DESCRIPTION
The specification states:
> This specification RECOMMENDS the use of `ECDH-ES` with the `X25519` curve for JWE
> as explained in section <a href="#encryption">Encryption</a> and described in

And then later in the encryption section states: 
>JWE encryption MUST use Diffie-Hellman key agreement, 

The "MUST" requirement is too strong, as it puts a requirement on the types of keys (e.g., EC keys vs RSA keys) an RP needs to support, as well as the specific curve for an EC key.

---
Also, even to make sense of the "RECOMMENDS" language: wouldn't  "`ECDH-ES` using the `X25519` curve" mean that the RP needs a `X25519` public key (vs the examples, which only show the RP providing a `secp256k1` public key). Is this point worth a follow-up PR to clarify?