### PR TITLE
Fixed case-sensitive imports

### DIFF
--- a/impl/demo/rp/rp-backend/libs/lib-did-siop/src/lib-did-siop.service.ts
+++ b/impl/demo/rp/rp-backend/libs/lib-did-siop/src/lib-did-siop.service.ts
@@ -5,7 +5,7 @@ import { getRandomString, getPemPubKey } from './util/Util'
 import { 
   SIOPRequest, SIOPResponseType, SIOPScope, 
   SIOPRequestCall, SIOPIndirectRegistration, SIOPDirectRegistration, 
-  SIOPRequestPayload, SIOPJwtHeader, SIOPResponseCall, SIOPResponse, SIOP_RESPONSE_ISS, SIOPResponsePayload, SIOP_KEY_TYPE } from './dtos/siop';
+  SIOPRequestPayload, SIOPJwtHeader, SIOPResponseCall, SIOPResponse, SIOP_RESPONSE_ISS, SIOPResponsePayload, SIOP_KEY_TYPE } from './dtos/SIOP';
 import { DIDDocument, getDIDDocument, PublicKey } from './dtos/DIDDocument'
 import { DID_SIOP_ERRORS } from './error'
 import base64url from "base64url";

--- a/impl/demo/siop/backend-wallet/libs/lib-did-siop/src/lib-did-siop.service.ts
+++ b/impl/demo/siop/backend-wallet/libs/lib-did-siop/src/lib-did-siop.service.ts
@@ -5,7 +5,7 @@ import { getRandomString, getPemPubKey } from './util/Util'
 import { 
   SIOPRequest, SIOPResponseType, SIOPScope, 
   SIOPRequestCall, SIOPIndirectRegistration, SIOPDirectRegistration, 
-  SIOPRequestPayload, SIOPJwtHeader, SIOPResponseCall, SIOPResponse, SIOP_RESPONSE_ISS, SIOPResponsePayload, SIOP_KEY_TYPE } from './dtos/siop';
+  SIOPRequestPayload, SIOPJwtHeader, SIOPResponseCall, SIOPResponse, SIOP_RESPONSE_ISS, SIOPResponsePayload, SIOP_KEY_TYPE } from './dtos/SIOP';
 import { DIDDocument, getDIDDocument, PublicKey } from './dtos/DIDDocument'
 import { DID_SIOP_ERRORS } from './error'
 import base64url from "base64url";


### PR DESCRIPTION
When building backend-wallet and rp-backend on Ubuntu 18.04.4, the following error occurred.

```
ERROR in libs/lib-did-siop/src/lib-did-siop.service.ts 8:131-144
TS2307: Cannot find module './dtos/siop' or its corresponding type declarations.
```
I think this is due to case sensitivity in TypeScript import except for macOS.
https://github.com/microsoft/TypeScript/issues/21736