### PR TITLE
getDIDDocument function has a bug

### DIFF
--- a/impl/demo/rp/rp-backend/libs/lib-did-siop/src/dtos/DIDDocument.ts
+++ b/impl/demo/rp/rp-backend/libs/lib-did-siop/src/dtos/DIDDocument.ts
@@ -102,7 +102,7 @@ export function ecKeyToDidDoc(key: JWK.Key): DIDDocument {
 }
 
 export function getDIDDocument(did: string): DIDDocument {
-  const base58PubKey:string = did.replace('did:key', '')
+  const base58PubKey:string = did.replace('did:key:', '')
   const keyId = `${did}#veri-key1`;
 
   const authentication:Authentication = {

--- a/impl/demo/siop/backend-wallet/libs/lib-did-siop/src/dtos/DIDDocument.ts
+++ b/impl/demo/siop/backend-wallet/libs/lib-did-siop/src/dtos/DIDDocument.ts
@@ -102,7 +102,7 @@ export function ecKeyToDidDoc(key: JWK.Key): DIDDocument {
 }
 
 export function getDIDDocument(did: string): DIDDocument {
-  const base58PubKey:string = did.replace('did:key', '')
+  const base58PubKey:string = did.replace('did:key:', '')
   const keyId = `${did}#veri-key1`;
 
   const authentication:Authentication = {


### PR DESCRIPTION
from
```javascript
 const base58PubKey:string = did.replace('did:key', '')
```

to
```javascript
 const base58PubKey:string = did.replace('did:key:', '')
```
